### PR TITLE
Added new static parameter and check the static parameters every 30 seconds 

### DIFF
--- a/src/app_active_mode_controller.c
+++ b/src/app_active_mode_controller.c
@@ -530,9 +530,6 @@ void APP_ACTIVE_MODE_CONTROLLER_Initialize ( void )
     app_active_mode_controllerData.resetFactorySettings = false;
     app_active_mode_controllerData.heatpumpForcedOff = false;
     
-    // Make sure arrays contain known values
-    SetDataInArraysAtStartup();
-    
     // Reset the system stuck protection counter
     setSystemStuckProtectionCounter(0);
     

--- a/src/app_heatpump_comm.c
+++ b/src/app_heatpump_comm.c
@@ -151,6 +151,9 @@ void APP_HEATPUMP_COMM_Initialize ( void )
 {
     SmartEepromInit();
     
+    // Make sure arrays contain known values
+    SetDataInArraysAtStartup();
+    
     //DMAC_ChannelCallbackRegister(DMAC_CHANNEL_3, APP_ReadCallbackHeatpump, 0);
     //DMAC_ChannelCallbackRegister(DMAC_CHANNEL_0, APP_WriteCallbackHeatpump, 0);
     
@@ -177,6 +180,7 @@ void APP_HEATPUMP_COMM_Initialize ( void )
         doFirstTimeHeatpumpCommunicationSettings = true;
     }
     
+    CheckHeatpumpStaticSettings();
     FillBufferWithStartupSettings(doFirstTimeHeatpumpCommunicationSettings);
     
     app_heatpump_commData.commStatus = HEATPUMP_COMM_STATUS_IDLE;
@@ -227,6 +231,9 @@ void APP_HEATPUMP_COMM_Tasks ( void )
         if (CommunicationTimeOutCounter < UINT32_MAX) {
             CommunicationTimeOutCounter++;
         }
+        
+        // Every 30 seconds the static settings are checked
+        CheckHeatpumpStaticSettings();
     }
     
     /* Check the application's current state. */

--- a/src/files/modbus/heatpump.c
+++ b/src/files/modbus/heatpump.c
@@ -300,13 +300,133 @@ void FillTxBuffer(uint8_t * txBuffer)
     }
 }
 
+uint16_t getHeatpumpData(uint16_t address)
+{
+    uint16_t returnData;
+    
+    // Known parameters
+    if ((address >= START_ADDRESS_REAL_TIME_DATA_STATUSSEN) && (address < START_ADDRESS_REAL_TIME_DATA_STATUSSEN + REGISTERS_AMOUNT_REAL_TIME_DATA_STATUSSEN))
+    {
+        address -= START_ADDRESS_REAL_TIME_DATA_STATUSSEN;
+        //RealTimeDataStatussen[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+        returnData = RealTimeDataStatussen[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_REAL_TIME_DATA) && (address < START_ADDRESS_REAL_TIME_DATA + REGISTERS_AMOUNT_REAL_TIME_DATA))
+    {
+        address -= START_ADDRESS_REAL_TIME_DATA;
+        returnData = RealTimeData[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_UNIT_SYSTEM_PARAMETERS) && (address < START_ADDRESS_UNIT_SYSTEM_PARAMETERS + REGISTERS_AMOUNT_UNIT_SYSTEM_PARAMETERS))
+    {
+        address -= START_ADDRESS_UNIT_SYSTEM_PARAMETERS;
+        returnData = UnitSystemParameters[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_USER_PARAMETERS) && (address < START_ADDRESS_USER_PARAMETERS + REGISTERS_AMOUNT_USER_PARAMETERS))
+    {
+        address -= START_ADDRESS_USER_PARAMETERS;
+        returnData = UserParameters[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_USER_ORDER) && (address < START_ADDRESS_USER_ORDER + REGISTERS_AMOUNT_USER_ORDER))
+    {
+        address -= START_ADDRESS_USER_ORDER;
+        returnData = UserOrder[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_VERSION_INFORMATION) && (address < START_ADDRESS_VERSION_INFORMATION + REGISTERS_AMOUNT_VERSION_INFORMATION))
+    {
+        address -= START_ADDRESS_VERSION_INFORMATION;
+        returnData = VersionInformation[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_UNIT_SYSTEM_PARAMETER_L) && (address < START_ADDRESS_UNIT_SYSTEM_PARAMETER_L + REGISTERS_AMOUNT_UNIT_SYSTEM_PARAMETER_L))
+    {
+        address -= START_ADDRESS_UNIT_SYSTEM_PARAMETER_L;
+        returnData = UnitSystemParameterL[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_COIL_ADDRESSES) && (address < START_ADDRESS_COIL_ADDRESSES + REGISTERS_AMOUNT_COIL_ADDRESSES))
+    {
+        address -= START_ADDRESS_COIL_ADDRESSES;
+        returnData = CoilAddresses[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    
+    // Unknown parameters
+    else if ((address >= START_ADDRESS_UNKNOWN_PARAMTERS_1) && (address < START_ADDRESS_UNKNOWN_PARAMTERS_1 + REGISTERS_AMOUNT_UNKNOWN_PARAMTERS_1))
+    {
+        address -= START_ADDRESS_UNKNOWN_PARAMTERS_1;
+        returnData = UnknownParameters1[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_UNKNOWN_PARAMTERS_2) && (address < START_ADDRESS_UNKNOWN_PARAMTERS_2 + REGISTERS_AMOUNT_UNKNOWN_PARAMTERS_2))
+    {
+        address -= START_ADDRESS_UNKNOWN_PARAMTERS_2;
+        returnData = UnknownParameters2[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_UNKNOWN_PARAMTERS_3) && (address < START_ADDRESS_UNKNOWN_PARAMTERS_3 + REGISTERS_AMOUNT_UNKNOWN_PARAMTERS_3))
+    {
+        address -= START_ADDRESS_UNKNOWN_PARAMTERS_3;
+        returnData = UnknownParameters3[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_UNKNOWN_PARAMTERS_4) && (address < START_ADDRESS_UNKNOWN_PARAMTERS_4 + REGISTERS_AMOUNT_UNKNOWN_PARAMTERS_4))
+    {
+        address -= START_ADDRESS_UNKNOWN_PARAMTERS_4;
+        returnData = UnknownParameters4[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_UNKNOWN_PARAMTERS_5) && (address < START_ADDRESS_UNKNOWN_PARAMTERS_5 + REGISTERS_AMOUNT_UNKNOWN_PARAMTERS_5))
+    {
+        address -= START_ADDRESS_UNKNOWN_PARAMTERS_5;
+        returnData = UnknownParameters5[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_UNKNOWN_PARAMTERS_6) && (address < START_ADDRESS_UNKNOWN_PARAMTERS_6 + REGISTERS_AMOUNT_UNKNOWN_PARAMTERS_6))
+    {
+        address -= START_ADDRESS_UNKNOWN_PARAMTERS_6;
+        returnData = UnknownParameters6[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_UNKNOWN_PARAMTERS_7) && (address < START_ADDRESS_UNKNOWN_PARAMTERS_7 + REGISTERS_AMOUNT_UNKNOWN_PARAMTERS_7))
+    {
+        address -= START_ADDRESS_UNKNOWN_PARAMTERS_7;
+        returnData = UnknownParameters7[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_UNKNOWN_PARAMTERS_8) && (address < START_ADDRESS_UNKNOWN_PARAMTERS_8 + REGISTERS_AMOUNT_UNKNOWN_PARAMTERS_8))
+    {
+        address -= START_ADDRESS_UNKNOWN_PARAMTERS_8;
+        returnData = UnknownParameters8[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else if ((address >= START_ADDRESS_UNKNOWN_PARAMTERS_9) && (address < START_ADDRESS_UNKNOWN_PARAMTERS_9 + REGISTERS_AMOUNT_UNKNOWN_PARAMTERS_9))
+    {
+        address -= START_ADDRESS_UNKNOWN_PARAMTERS_9;
+        returnData = UnknownParameters9[address][PARAMETER_ARRAY_DATA_READ_FROM_HEATPUMP];
+    }
+    else
+    {
+        returnData = UINT16_MAX; 
+    }
+    
+    return returnData;
+}
+
+uint16_t getWaterFlowProtectionValue(uint16_t unitToolingNumber)
+{
+    if ((unitToolingNumber == CURRENT_UNIT_TOOLING_NO_6KW_1) || (unitToolingNumber == CURRENT_UNIT_TOOLING_NO_6KW_2)) {
+        // 6KW unit
+        return 5;
+    }
+    
+    if ((unitToolingNumber == CURRENT_UNIT_TOOLING_NO_12KW_1) || (unitToolingNumber == CURRENT_UNIT_TOOLING_NO_12KW_2)) {
+        // 12KW unit
+        return 10;
+    }
+    
+    if ((unitToolingNumber == CURRENT_UNIT_TOOLING_NO_18KW_1) || (unitToolingNumber == CURRENT_UNIT_TOOLING_NO_18KW_2)) {
+        // 18KW unit
+        return 15;
+    }
+    
+    return UINT16_MAX;
+}
 
 void FillBufferWithStartupSettings(bool doFirstTimeHeatpumpCommunicationSettings) {
-    ChangeHeatpumpSetting(ADDRESS_PARAMETER_PASSWORD_SETTING, 255);
-    ChangeHeatpumpSetting(ADDRESS_TANK_TEMPERATURE_PROBE_ENABLED, TANK_TEMPERATURE_PROBE_DISABLED); 
-    ChangeHeatpumpSetting(ADDRESS_UNIT_TEMPERATURE_CONTROL_METHOD, UNIT_TEMPERATURE_CONTROL_METHOD_RETURN_WATER); 
-    ChangeHeatpumpSetting(ADDRESS_HIGH_TEMPERATURE_STERILIZATION_FUNCTION, 0);  
-    ChangeHeatpumpSetting(ADDRESS_DEVICE_REACHING_TARGET_TEMPERATURE_AND_SHUTDOWN_MODE, 1); 
+    //ChangeHeatpumpSetting(ADDRESS_PARAMETER_PASSWORD_SETTING, 255);
+    //ChangeHeatpumpSetting(ADDRESS_TANK_TEMPERATURE_PROBE_ENABLED, TANK_TEMPERATURE_PROBE_DISABLED); 
+    //ChangeHeatpumpSetting(ADDRESS_UNIT_TEMPERATURE_CONTROL_METHOD, UNIT_TEMPERATURE_CONTROL_METHOD_RETURN_WATER); 
+    //ChangeHeatpumpSetting(ADDRESS_HIGH_TEMPERATURE_STERILIZATION_FUNCTION, 0);  
+    //ChangeHeatpumpSetting(ADDRESS_DEVICE_REACHING_TARGET_TEMPERATURE_AND_SHUTDOWN_MODE, 1); 
     
     if (doFirstTimeHeatpumpCommunicationSettings == true)
     {
@@ -318,6 +438,43 @@ void FillBufferWithStartupSettings(bool doFirstTimeHeatpumpCommunicationSettings
     }      
 }
 
+void CheckHeatpumpStaticSettings() {
+    if (getCheckHeatpumpStaticSettingsCounter() < 30) {
+        return;
+    }
+    
+    setCheckHeatpumpStaticSettingsCounter(0);
+
+    if (getHeatpumpData(ADDRESS_PARAMETER_PASSWORD_SETTING) != 255) { 
+        ChangeHeatpumpSetting(ADDRESS_PARAMETER_PASSWORD_SETTING, 255);
+    }
+    
+    if (getHeatpumpData(ADDRESS_TANK_TEMPERATURE_PROBE_ENABLED) != TANK_TEMPERATURE_PROBE_DISABLED) { 
+        ChangeHeatpumpSetting(ADDRESS_TANK_TEMPERATURE_PROBE_ENABLED, TANK_TEMPERATURE_PROBE_DISABLED);
+    }
+    
+    if (getHeatpumpData(ADDRESS_UNIT_TEMPERATURE_CONTROL_METHOD) != UNIT_TEMPERATURE_CONTROL_METHOD_RETURN_WATER) { 
+        ChangeHeatpumpSetting(ADDRESS_UNIT_TEMPERATURE_CONTROL_METHOD, UNIT_TEMPERATURE_CONTROL_METHOD_RETURN_WATER);
+    }
+    
+    if (getHeatpumpData(ADDRESS_HIGH_TEMPERATURE_STERILIZATION_FUNCTION) != 0) { 
+        ChangeHeatpumpSetting(ADDRESS_HIGH_TEMPERATURE_STERILIZATION_FUNCTION, 0);
+    }
+    
+    if (getHeatpumpData(ADDRESS_DEVICE_REACHING_TARGET_TEMPERATURE_AND_SHUTDOWN_MODE) != 1) { 
+        ChangeHeatpumpSetting(ADDRESS_DEVICE_REACHING_TARGET_TEMPERATURE_AND_SHUTDOWN_MODE, 1);
+    }
+    
+    
+    uint16_t correctWaterFlowProtectionValue = getWaterFlowProtectionValue(getHeatpumpData(ADDRESS_CURRENT_UNIT_TOOLING_NO));
+    
+    if (correctWaterFlowProtectionValue != UINT16_MAX){
+        // Value is not UINT16_MAX, so it can be checked with its current value, otherwise skip this
+        if (getHeatpumpData(ADDRESS_WATER_FLOW_IS_TOO_LOW_PROTECTION_VALUE) != correctWaterFlowProtectionValue) {
+            ChangeHeatpumpSetting(ADDRESS_WATER_FLOW_IS_TOO_LOW_PROTECTION_VALUE, correctWaterFlowProtectionValue);
+        }
+    }
+}
 
 /*
 uint8_t FillBufferWithStartupSettings(bool doFirstTimeHeatpumpCommunicationSettings)

--- a/src/files/modbus/heatpump.h
+++ b/src/files/modbus/heatpump.h
@@ -7,6 +7,7 @@
 void ParseHeatpumpData(uint8_t * txBufferHeatpump, uint8_t * rxBufferHeatpump);
 void FillTxBuffer(uint8_t * txBuffer);
 void FillBufferWithStartupSettings(bool doFirstTimeHeatpumpCommunicationSettings);
+void CheckHeatpumpStaticSettings();
 char * getHeatpumpStateToString(APP_HEATPUMP_COMM_STATES logState);
 
 #endif /* _HEATPUMP_H */

--- a/src/files/modbus/heatpump_parameters.h
+++ b/src/files/modbus/heatpump_parameters.h
@@ -29,6 +29,12 @@
 #define ADDRESS_SWITCH_PORT_STATE_3             0x001F
 #define ADDRESS_SWITCH_PORT_STATE_4             0x0020
 #define ADDRESS_CURRENT_UNIT_TOOLING_NO         0x0024 
+    #define CURRENT_UNIT_TOOLING_NO_6KW_1       115     // 6KW heatpump can be Unit Tooling Nr. 115 or 129
+    #define CURRENT_UNIT_TOOLING_NO_6KW_2       129
+    #define CURRENT_UNIT_TOOLING_NO_12KW_1      116     // 12KW heatpump can be Unit Tooling Nr. 116 or 130
+    #define CURRENT_UNIT_TOOLING_NO_12KW_2      130
+    #define CURRENT_UNIT_TOOLING_NO_18KW_1      117     // 18KW heatpump can be Unit Tooling Nr. 117 or 131
+    #define CURRENT_UNIT_TOOLING_NO_18KW_2      131
 #define ADDRESS_COMPRESSOR_1_TARGET_FREQUENCY   0x0027
 #define ADDRESS_COMPRESSOR_2_TARGET_FREQUENCY   0x0028
 

--- a/src/files/time_counters.c
+++ b/src/files/time_counters.c
@@ -24,6 +24,7 @@ uint32_t waitForSettingEchoProtection = UINT32_MAX;
 uint32_t writeHeatpumpRunningModeCounter = UINT32_MAX;
 uint32_t writeHeatpumpForcedOffCounter = UINT32_MAX;
 uint32_t WaitingTurningHeatpumpOnCounter = UINT32_MAX;
+uint32_t checkHeatpumpStaticSettingsCounter = UINT32_MAX;
 
 //static uint32_t SecondCounterFtp = UINT32_MAX;
 //static uint32_t SecondCounterResetSoftware = UINT32_MAX;
@@ -158,6 +159,10 @@ void UpdateCounters ( void )
             if (WaitingTurningHeatpumpOnCounter >= 0 && WaitingTurningHeatpumpOnCounter < UINT32_MAX) {
                 WaitingTurningHeatpumpOnCounter++;
             }
+            
+            if (checkHeatpumpStaticSettingsCounter >= 0 && checkHeatpumpStaticSettingsCounter < UINT32_MAX) {
+                checkHeatpumpStaticSettingsCounter++;
+            }
         }   
 
         if (SecondCounterLeds >= 0 && SecondCounterLeds < UINT32_MAX)
@@ -247,6 +252,14 @@ uint32_t getWaitingTurningHeatpumpOn() {
 
 void setWaitingTurningHeatpumpOn(uint32_t value) {
     WaitingTurningHeatpumpOnCounter = value;
+}
+
+uint32_t getCheckHeatpumpStaticSettingsCounter() {
+    return checkHeatpumpStaticSettingsCounter;
+}
+
+void setCheckHeatpumpStaticSettingsCounter(uint32_t value) {
+    checkHeatpumpStaticSettingsCounter = value;
 }
 
 bool LedsTimerExpired ( void )

--- a/src/files/time_counters.h
+++ b/src/files/time_counters.h
@@ -47,6 +47,8 @@ uint32_t getWriteHeatpumpForcedOffCounter();
 void setWriteHeatpumpForcedOffCounter(uint32_t value);
 uint32_t getWaitingTurningHeatpumpOn();
 void setWaitingTurningHeatpumpOn(uint32_t value);
+uint32_t getCheckHeatpumpStaticSettingsCounter();
+void setCheckHeatpumpStaticSettingsCounter(uint32_t value);
 
 bool LedsTimerExpired ( void );
 bool HeatingHotWaterTimerExpired ( void );


### PR DESCRIPTION
- Added parameter ADDRESS_WATER_FLOW_IS_TOO_LOW_PROTECTION_VALUE which is set to a static value dependent on the Unit Tooling Nr. of the heatpump.
- All parameters which were set at startup of the application, are now checked every 30 seconds if they are the correct value, if not they are set to the correct value.